### PR TITLE
Build improvements for msvc 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 .vs/
 *.sln
 *.vcxproj*
+CMakeSettings.json
 
 # VST specific
 *.vst
@@ -62,9 +63,6 @@ Win32/
 install_manifest.txt
 out.wav
 Testing/
-
-# Build Tree
-/buildx86
-/buildx64
+CMakeBuild
 
 Steinberg

--- a/Common/common.cmake
+++ b/Common/common.cmake
@@ -128,22 +128,22 @@ endfunction(add_vstgui)
 #*******************************************************************************
 function(add_tests VST_TARGET)
   if(WIN32)
-    if(PLUGIN_ARCH STREQUAL "x86")
-      # message("Adding tests for x86")
-      add_test(
-        NAME MrsWatson-${VST_TARGET}-32
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
-        COMMAND bin\\win\\mrswatson -p $<SHELL_PATH:$<TARGET_FILE:${VST_TARGET}>> -i media\\input.wav -o out.wav
-      )
-    elseif(PLUGIN_ARCH STREQUAL "x64")
-      # message("Adding tests for x64")
-      add_test(
-        NAME MrsWatson-${VST_TARGET}-64
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
-        COMMAND bin\\win\\mrswatson64 -p $<SHELL_PATH:$<TARGET_FILE:${VST_TARGET}>> -i media\\input.wav -o out.wav
-      )
+    if(MSVC)
+      if (CMAKE_GENERATOR MATCHES ".*Win64$")
+        add_test(
+          NAME MrsWatson-${VST_TARGET}-64
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+          COMMAND bin\\win\\mrswatson64 -p $<SHELL_PATH:$<TARGET_FILE:${VST_TARGET}>> -i media\\input.wav -o out.wav
+        )
+      else()
+        add_test(
+          NAME MrsWatson-${VST_TARGET}-32
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+          COMMAND bin\\win\\mrswatson -p $<SHELL_PATH:$<TARGET_FILE:${VST_TARGET}>> -i media\\input.wav -o out.wav
+        )
+      endif()
     else()
-      message(SEND_ERROR "PLUGIN_ARCH needs to be set to x64 or x86")
+      message(WARNING "Tests currently not supported for ${CMAKE_GENERATOR}")
     endif()
   elseif(APPLE)
     add_test(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
   - ps: .\build.ps1 -Verbose $env:PLATFORM $env:CONFIGURATION
 
 after_build:
-  - ps: 7z a Win-Plugins-$env:PLATFORM.zip .\build$env:PLATFORM\*\Release\*.dll
+  - ps: 7z a Win-Plugins-$env:PLATFORM.zip .\CMakeBuild\$env:PLATFORM\*\Release\*.dll
 
 artifacts:
   - path: Win-Plugins-$(PLATFORM).zip


### PR DESCRIPTION
Visual Studio 2017 has 'open folder' feature for projects now. This allows you to open cmake based projects directly without generating msvc projects manually. Originally I just wanted to change the required PLUGIN_ARCH define so there would be less setup hassles but I went ahead and made a few other improvements while I was at it.

- Auto-detect architecture

- Common base folder for builds i.e. CMakeBuild

- Update .gitignore to handle changes / new files