### PR TITLE
Use the right array destructor for SupaTrigga

### DIFF
--- a/SupaTrigga/SupaTrigger.cpp
+++ b/SupaTrigga/SupaTrigger.cpp
@@ -57,8 +57,8 @@ SupaTrigger::SupaTrigger(audioMasterCallback audioMaster) : AudioEffectX(audioMa
 //-----------------------------------------------------------------------------------------
 SupaTrigger::~SupaTrigger()
 {
-    delete leftBuffer;
-    delete rightBuffer;
+    delete[] leftBuffer;
+    delete[] rightBuffer;
 }
 
 //-----------------------------------------------------------------------------------------

--- a/SupaTrigga/SupaTrigger.cpp
+++ b/SupaTrigga/SupaTrigger.cpp
@@ -325,8 +325,8 @@ void SupaTrigger::processReplacing(float **inputs, float **outputs, VstInt32 sam
             {
                 if(first)
                 {
-                    unsigned long sliceSize = samplesInMeasure >> granularity;
-                    unsigned long sliceStart = (positionInMeasure / sliceSize) * sliceSize;
+                    //unsigned long sliceSize = samplesInMeasure >> granularity;
+                    //unsigned long sliceStart = (positionInMeasure / sliceSize) * sliceSize;
 
                     position = (float) ((positionInMeasure) - (displacement * samplesInMeasure)/MAXSLIDES);
                     speed = 1.f/speedDiff;


### PR DESCRIPTION
The 2x 2M float arrays (16MB) allocated for stereo buffer are deallocated with the wrong destructor.

_And btw, cant count the number of times we should thank you for those fantastic plugs. Lets assume it's beyond billions._