### PR TITLE
Fix changed URL for VSTSDK

### DIFF
--- a/get_steinberg_sdk.py
+++ b/get_steinberg_sdk.py
@@ -20,12 +20,12 @@ class ProgressReporter:
             self.progress = progress
 
 
-url = "http://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip"  # noqa
+url = "https://www.steinberg.net/vst3sdk"  # noqa
 urlretrieve(url, "Steinberg.zip", ProgressReporter())
 
 zip = ZipFile('Steinberg.zip')
 zip.extractall()
 
 shutil.rmtree("Steinberg", ignore_errors=True)
-os.rename("VST3 SDK", "Steinberg")
+os.rename("VST_SDK", "Steinberg")
 shutil.rmtree("Steinberg.zip", ignore_errors=True)


### PR DESCRIPTION
**NOTE:** this PR is incomplete and needs more work, but it's definitely heading in the right direction.

Please someone else check that this works for them, but it sure works for me!
Except something isn't quite right, as after this I get a build error:

`[cmake]   Cannot find source file:
[cmake] 
[cmake]     ..../smartelectronix/Steinberg/public.sdk/source/vst2.x/audioeffect.cpp`

Which looks like it's due to the new folder: `vstsdk2` sitting above `public.sdk` so the build scripts need to be changed to reflect this....

I tried manually editing `smartelecronix/Common/common.cmake` with the new paths, but it didn't help.

Even doing that doesn't fix it since aeffect.h doesn't exist in the new SDK. @bdejong any ideas?