### PR TITLE
Change smexoscope dark mode toggle to double-click

### DIFF
--- a/smexoscope/Source/PluginEditor.cpp
+++ b/smexoscope/Source/PluginEditor.cpp
@@ -167,12 +167,14 @@ void SmexoscopeEditor::updateLabels()
     threshLabel->setText(processorRef.getDisplayText(SmexoscopeProcessor::PARAM_TRIGGER_LIMIT), juce::dontSendNotification);
 }
 
-bool SmexoscopeEditor::keyPressed(const juce::KeyPress&)
+void SmexoscopeEditor::mouseDown (const juce::MouseEvent& event)
 {
-    useDarkSkin = !useDarkSkin;
-    processorRef.useDarkSkin = useDarkSkin;
-    applySkin(useDarkSkin);
-    return true;
+    if (event.getNumberOfClicks() == 2)
+    {
+        useDarkSkin = !useDarkSkin;
+        processorRef.useDarkSkin = useDarkSkin;
+        applySkin(useDarkSkin);
+    }
 }
 
 void SmexoscopeEditor::applySkin(bool dark)

--- a/smexoscope/Source/PluginEditor.h
+++ b/smexoscope/Source/PluginEditor.h
@@ -15,7 +15,7 @@ public:
 
     void paint(juce::Graphics&) override;
     void resized() override {}
-    bool keyPressed(const juce::KeyPress& key) override;
+    void mouseDown (const juce::MouseEvent& event) override;
 
 private:
     void timerCallback() override;


### PR DESCRIPTION
The previous change to smexoscope was to use a key press to toggle dark mode.
The issue with that is that you are often mousing-over the smexoscope window whilst you are playing the keyboard for notes in the DAW, which generates a christmas display.

This change means that you can now just double click to change, and this no longer clashes with any standard functionality go the plugin nor the daw, it's unique, and therefore easier to work with.

I've made this change, worked with it in Ableton for a few days, and I like it a lot more.

Thanks @bdejong I hope you consider this change.

I also emailed you a signed CLA in anticipation of this PR.